### PR TITLE
Fix function name with typo in solr-utils

### DIFF
--- a/app/views/features/_related.html.erb
+++ b/app/views/features/_related.html.erb
@@ -50,7 +50,7 @@
   });
 
   //Related Counts on Solr
-  relatedSolrUtils.getDirectDescendatCount().then(function(count){
+  relatedSolrUtils.getDirectDescendantCount().then(function(count){
       $(".relatedCountContainer").each(function(){
           $(this).html(count);
       });


### PR DESCRIPTION
Fix the call to the function that had a typo in solr-utils