### PR TITLE
Fix bug that not all relationships were displayed on summary - MANU-5694

### DIFF
--- a/app/assets/javascripts/subjects_engine/related-section-initializer.js
+++ b/app/assets/javascripts/subjects_engine/related-section-initializer.js
@@ -20,7 +20,7 @@ $(function() {
         var feature_path = $('#related_js_data').data('featurePath');
         relatedSolrUtils.addSubjectsSummaryItems(feature_label,feature_path,'parent',result);
         relatedSolrUtils.addSubjectsSummaryItems(feature_label,feature_path,'child',result);
-        //relatedSolrUtils.addSubjectsSummaryItems(feature_label,feature_path,'other',result);
+        relatedSolrUtils.addSubjectsSummaryItems(feature_label,feature_path,'other',result);
 
         if(!collapsibleApplied){
           $('ul.collapsibleList').kmapsCollapsibleList();

--- a/lib/subjects_engine/version.rb
+++ b/lib/subjects_engine/version.rb
@@ -1,3 +1,3 @@
 module SubjectsEngine
-  VERSION = '1.4.8'
+  VERSION = '1.4.9'
 end


### PR DESCRIPTION
**Jira Issue:**  MANU-5694
**Changes proposed in this pull request:**

 + Include all relationships on summary tab for feature relationships

**Details of the implementation:**

Only parent and child relationships were being displayed on the summary
tab this is being fixed by this commit.
